### PR TITLE
Tweak Sadko mailbox entry to ease on LV2 validation failures

### DIFF
--- a/src/main/meta/developers.cpp
+++ b/src/main/meta/developers.cpp
@@ -30,7 +30,7 @@ namespace lsp
             "v_sadovnikov",
             "SadKo",
             "Vladimir Sadovnikov",
-            "lsp.plugin@gmail.com",
+            "lsp.plugin+sadko@gmail.com",
             "http://lsp-plug.in/"
         };
 


### PR DESCRIPTION
As what title says.
Issue comes from using the same foaf:mailbox entry for 2 different distinct objects, resulting on this output from `lv2_validate`:

```
error: Inverse functional property with 2 subjects
       http://lsp-plug.in/developers/lsp
       http://xmlns.com/foaf/0.1/mbox
       mailto:lsp.plugin@gmail.com
error: Inverse functional property with 2 subjects
       http://lsp-plug.in/developers/v_sadovnikov
       http://xmlns.com/foaf/0.1/mbox
       mailto:lsp.plugin@gmail.com
Found 2 errors among 86 files (checked 28269 restrictions)
```

The change bypasses the issue by making the email a different value.

Related to https://github.com/lsp-plugins/lsp-plugins-art-delay/pull/3
