### PR TITLE
Stop claiming copyright for year of build

### DIFF
--- a/src/doc/index.php
+++ b/src/doc/index.php
@@ -68,7 +68,7 @@
 			<!-- Footer -->
 			<div id="footer">
 				<div style="padding:0 10px 10px 10px">
-				<p>&copy; Linux Studio Plugins Project, 2015-<?= date('Y') ?></p>
+				<p>&copy; Linux Studio Plugins Project, 2015-2023</p>
 				<p>All rights reserved</p>
 				</div>
 			</div>


### PR DESCRIPTION
Without this patch, building in the year 2039 results in such `/usr/share/doc/packages/lsp-plugins/html/development/eclipse.html`

```html
                               <p>&copy; Linux Studio Plugins Project, 2015-2039</p>
                               <p>All rights reserved</p>
```

which is incorrect, because nobody did anything copyright-worthy in this version in the year 2039.